### PR TITLE
Tesselator | Create Structurer to process lines into structured meshes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(tessellator
     "tessellator/Smoother.cpp"
     "tessellator/SmootherTools.cpp"
     "tessellator/Snapper.cpp"
+    "tessellator/Structurer.cpp"
     "tessellator/filler/Filler.cpp"
     "tessellator/filler/FillerTools.cpp"
     "tessellator/filler/SegmentsArray.cpp"

--- a/src/tessellator/Slicer.h
+++ b/src/tessellator/Slicer.h
@@ -28,12 +28,14 @@ private:
     std::mutex writingCoordinates_;
     std::mutex writingElements_;
     Mesh mesh_;
-    
+
     Elements sliceTriangle(Coordinates&, const TriV&);
+    Elements sliceLine(Coordinates&, const LinV&);
     
+    template<std::size_t N>
     IdSet buildIntersectionsWithGridPlanes(
         Coordinates& sCoords,
-        const TriV& tri);
+        const ElemV<N>& tri);
     
     CellCoordIdMap buildCellCoordIdMap(
         Coordinates& sCoords,

--- a/src/tessellator/Structurer.cpp
+++ b/src/tessellator/Structurer.cpp
@@ -1,0 +1,228 @@
+#include "Structurer.h"
+
+#include "utils/Cleaner.h"
+
+namespace meshlib {
+namespace tessellator {
+using namespace utils;
+
+Structurer::Structurer(const Mesh& inputMesh) : GridTools(inputMesh.grid)
+{
+    mesh_.grid = inputMesh.grid;
+
+    mesh_.coordinates.reserve(inputMesh.coordinates.size() * 2);
+
+    mesh_.groups.resize(inputMesh.groups.size());
+
+    for (std::size_t g = 0; g < mesh_.groups.size(); ++g) {
+
+        auto& inputGroup = inputMesh.groups[g];
+        auto& meshGroup = mesh_.groups[g];
+        meshGroup.elements.reserve(inputGroup.elements.size() * 2);
+
+        for (auto & element : inputGroup.elements) {
+            if (element.isLine()) {
+                this->processLineAndAddToGroup(element, inputMesh.coordinates, meshGroup);
+            }
+        }
+    }
+
+    Cleaner::fuseCoords(mesh_);
+    Cleaner::cleanCoords(mesh_);
+}
+
+
+void Structurer::processLineAndAddToGroup(const Element& line, const Coordinates& originalRelativeCoordinates, Group& group) {
+    auto startRelative = originalRelativeCoordinates[line.vertices[0]];
+    auto endRelative = originalRelativeCoordinates[line.vertices[1]];
+
+    auto startCell = this->calculateStructuredCell(startRelative);
+    auto endCell = this->calculateStructuredCell(endRelative);
+
+    std::vector<Cell> cells = { startCell };
+
+    short difference = 0;
+
+    for (std::size_t axis = 0; axis < 3; ++axis) {
+        if (startCell[axis] != endCell[axis]) {
+            ++difference;
+        }
+    }
+    
+    if (difference == 2) {
+        Relative startStructuredRelative = this->toRelative(startCell);
+        Relative endStructuredRelative = this->toRelative(endCell);
+
+        std::vector<std::size_t> differentAxes;
+        differentAxes.reserve(2);
+        for (std::size_t axis = 0; axis < 3; ++axis) {
+            if (startCell[axis] != endCell[axis]) {
+                differentAxes.push_back(axis);
+            }
+        }
+
+        Relative candidateOne = startStructuredRelative;
+        Relative candidateTwo = startStructuredRelative;
+        candidateOne[differentAxes[0]] = endStructuredRelative[differentAxes[0]];
+        candidateTwo[differentAxes[1]] = endStructuredRelative[differentAxes[1]];
+        Relative startToCandidateOne = candidateOne - startRelative;
+        Relative startToCandidateTwo = candidateTwo - startRelative;
+        Relative endToCandidateOne = candidateOne - endRelative;
+        Relative endToCandidateTwo = candidateTwo - endRelative;
+        
+        auto startToCandidateOneMagnitude = sqrt(pow(startToCandidateOne[0], 2) + pow(startToCandidateOne[1], 2) + pow(startToCandidateOne[2], 2));
+        auto startToCandidateTwoMagnitude = sqrt(pow(startToCandidateTwo[0], 2) + pow(startToCandidateTwo[1], 2) + pow(startToCandidateTwo[2], 2));
+        auto endToCandidateOneMagnitude = sqrt(pow(endToCandidateOne[0], 2) + pow(endToCandidateOne[1], 2) + pow(endToCandidateOne[2], 2));
+        auto endToCandidateTwoMagnitude = sqrt(pow(endToCandidateTwo[0], 2) + pow(endToCandidateTwo[1], 2) + pow(endToCandidateTwo[2], 2));
+
+        if (approxDir(startToCandidateOneMagnitude - startToCandidateTwoMagnitude, 0.0)
+            && approxDir(endToCandidateOneMagnitude - endToCandidateTwoMagnitude, 0.0)) {
+            cells.push_back(this->toCell(candidateOne));
+        }
+        else {
+            Coordinate startExtreme = startRelative;
+            Coordinate endExtreme = endRelative;
+            Cell middleCell;
+            std::size_t tries = 0;
+            do {
+                if (tries > 40) {
+                    throw std::logic_error("Stuck in infinite loop.");
+                }
+                const Coordinate middlePoint = startExtreme + (endExtreme - startExtreme) / 2.0;
+                middleCell = this->calculateStructuredCell(middlePoint);
+
+                if (middleCell == startCell) {
+                    startExtreme = middlePoint;
+                }
+                else if (middleCell == endCell) {
+                    endExtreme = middlePoint;
+                }
+
+                ++tries;
+
+            } while (middleCell == startCell || middleCell == endCell);
+            cells.push_back(middleCell);
+        }
+    }
+    else if (difference == 3) {
+        Relative startStructuredRelative = this->toRelative(startCell);
+        Relative endStructuredRelative = this->toRelative(endCell);
+
+        Coordinate startCoordinateDist = (startRelative - startStructuredRelative).abs();
+        Coordinate endCoordinateDist = (endRelative - endStructuredRelative).abs();
+
+        if (approxDir(startCoordinateDist[x] - startCoordinateDist[y], 0.0) && approxDir(startCoordinateDist[x] - startCoordinateDist[z], 0.0)
+            && approxDir(endCoordinateDist[x] - endCoordinateDist[y], 0.0) && approxDir(endCoordinateDist[x] - endCoordinateDist[z], 0.0)) {
+            cells.push_back(Cell({ endCell[x], startCell[y], startCell[z] }));
+            cells.push_back(Cell({ endCell[x], endCell[y], startCell[z] }));
+        }
+        else {
+            Coordinate startExtreme = startRelative;
+            Coordinate endExtreme = endRelative;
+            Coordinate middle = startExtreme + (endExtreme - startExtreme) / 2.0;
+            Coordinate thirdStep = (endRelative - startRelative) / 3.0;
+            Coordinate secondPoint = startRelative + thirdStep;
+            Coordinate thirdPoint = secondPoint + thirdStep;
+            Cell secondCell = this->calculateStructuredCell(secondPoint);
+            Cell thirdCell = this->calculateStructuredCell(thirdPoint);
+
+            auto secondCellDifference = calculateDifferenceBetweenCells(startCell, secondCell);
+            auto betweenCellsDifference = calculateDifferenceBetweenCells(secondCell, thirdCell);
+            auto thirdCellDifference = calculateDifferenceBetweenCells(thirdCell, endCell);
+
+            
+            std::size_t tries = 0;
+            while (secondCellDifference != 1) {
+                if (tries > 200) {
+                    throw std::logic_error("Stuck in infinite loop.");
+                }
+                ++tries;
+                if (secondCellDifference == 0)
+                {
+                    startExtreme = secondPoint;
+                }
+                else if (secondCellDifference > 1) {
+                    endExtreme = secondPoint;
+                }
+                secondPoint = startExtreme + (endExtreme - startExtreme) / 2.0;
+                secondCell = this->calculateStructuredCell(secondPoint);
+                secondCellDifference = calculateDifferenceBetweenCells(startCell, secondCell);
+            }
+            
+            startExtreme = secondPoint;
+            endExtreme = endRelative;
+            betweenCellsDifference = calculateDifferenceBetweenCells(secondCell, thirdCell);
+            thirdCellDifference = calculateDifferenceBetweenCells(thirdCell, endCell);
+
+            tries = 0;
+            while (betweenCellsDifference != 1 && thirdCellDifference != 1) {
+                if (tries > 200) {
+                    throw std::logic_error("Stuck in infinite loop.");
+                }
+                ++tries;
+
+                if (thirdCellDifference == 0)
+                {
+                    endExtreme = thirdPoint;
+                }
+                else if (thirdCellDifference > 1) {
+                    startExtreme = thirdPoint;
+                }
+                thirdPoint = startExtreme + (endExtreme - startExtreme) / 2.0;
+                thirdCell = this->calculateStructuredCell(thirdPoint);
+                betweenCellsDifference = calculateDifferenceBetweenCells(secondCell, thirdCell);
+                thirdCellDifference = calculateDifferenceBetweenCells(thirdCell, endCell);
+            }
+            cells.push_back(secondCell);
+            cells.push_back(thirdCell);
+        }
+    }
+
+    cells.push_back(endCell);
+
+    auto startRelativePosition = this->toRelative(cells[0]);
+    CoordinateId startIndex = mesh_.coordinates.size();
+    mesh_.coordinates.push_back(startRelativePosition);
+
+    for (std::size_t v = 1; v < cells.size(); ++v) {
+        auto endRelativePosition = this->toRelative(cells[v]);
+        CoordinateId endIndex = startIndex + 1;
+        mesh_.coordinates.push_back(endRelativePosition);
+
+        group.elements.push_back(Element({ startIndex, endIndex }, Element::Type::Line));
+
+        std::swap(startRelativePosition, endRelativePosition);
+        ++startIndex;
+    }
+}
+
+Cell Structurer::calculateStructuredCell(const Coordinate& relativeCoordinate) const
+{
+    auto resultCell = this->toCell(relativeCoordinate);
+
+    for (std::size_t axis = 0; axis < 3; ++axis) {
+        auto distance = relativeCoordinate[axis] - resultCell[axis];
+
+        if (distance >= 0.5) {
+            ++resultCell[axis];
+        }
+    }
+
+    return resultCell;
+}
+
+std::size_t Structurer::calculateDifferenceBetweenCells(const Cell& firstCell, const Cell& secondCell){
+    short difference = 0;
+
+    for (std::size_t axis = 0; axis < 3; ++axis) {
+        if (firstCell[axis] != secondCell[axis]) {
+            ++difference;
+        }
+    }
+    return difference;
+
+}
+
+
+}
+}

--- a/src/tessellator/Structurer.h
+++ b/src/tessellator/Structurer.h
@@ -17,7 +17,10 @@ private:
 
     void processLineAndAddToGroup(const Element& line, const Coordinates& originalRelativeCoordinates, Group & group);
     std::size_t calculateDifferenceBetweenCells(const Cell& firstCell, const Cell& secondCell);
+    Cell calculateMiddleCellBetweenTwoCoordinates(Coordinate& startExtreme, Coordinate& endExtreme, Relative& step);
+
 };
+
 
 }
 }

--- a/src/tessellator/Structurer.h
+++ b/src/tessellator/Structurer.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "utils/GridTools.h"
+
+namespace meshlib {
+namespace tessellator {
+
+class Structurer : public utils::GridTools {
+public:
+    Structurer(const Mesh&);
+    Mesh getMesh() const { return mesh_; };
+
+    Cell calculateStructuredCell(const Coordinate& relativeCoordinate) const;
+
+private:
+    Mesh mesh_;
+
+    void processLineAndAddToGroup(const Element& line, const Coordinates& originalRelativeCoordinates, Group & group);
+    std::size_t calculateDifferenceBetweenCells(const Cell& firstCell, const Cell& secondCell);
+};
+
+}
+}

--- a/src/tessellator/filler/Slice.cpp
+++ b/src/tessellator/filler/Slice.cpp
@@ -67,8 +67,8 @@ std::array<ArrayIndex, 2> buildMinAndMaxArrayIndices(const Bbox2& bbox)
 		std::numeric_limits<CellDir>::max()
 	};
 	ArrayIndex maxAI{
-		std::numeric_limits<CellDir>::min(),
-		std::numeric_limits<CellDir>::min()
+		std::numeric_limits<CellDir>::lowest(),
+		std::numeric_limits<CellDir>::lowest()
 	};
 	for (auto d{ 0 }; d < 2; ++d) {
 		if ((CellDir)std::floor(bbox.min(d)) < minAI[d]) {
@@ -107,8 +107,8 @@ Bbox2 getBoundingBox(const Polylines2& pls)
 		std::numeric_limits<KType>::max()
 	};
 	std::array<KType, 2> max{
-		std::numeric_limits<KType>::min(),
-		std::numeric_limits<KType>::min()
+		std::numeric_limits<KType>::lowest(),
+		std::numeric_limits<KType>::lowest()
 	};
 	for (const auto& pl : pls) {
 		assert(!pl.empty());

--- a/src/types/Mesh.h
+++ b/src/types/Mesh.h
@@ -44,6 +44,10 @@ struct Element {
         return type == Type::None && vertices.size() == 0;
     }
 
+    bool isNode() const
+    {
+        return type == Type::Node && vertices.size() == 1;
+    }
 
     bool isLine() const 
     {

--- a/src/utils/Geometry.cpp
+++ b/src/utils/Geometry.cpp
@@ -81,6 +81,18 @@ TriV Geometry::asTriV(const Element& el, const std::vector<Coordinate>& co) {
     return res;
 }
 
+
+LinV Geometry::asLinV(const Element& el, const std::vector<Coordinate>& co) {
+    if (el.vertices.size() != 2) {
+        throw std::logic_error("Invalid conversion from element to LinV");
+    }
+    LinV res;
+    for (std::size_t i = 0; i < el.vertices.size(); i++) {
+        res[i] = co[el.vertices[i]];
+    }
+    return res;
+}
+
 bool Geometry::approximatelyAligned(
     const TriV& a, const TriV& b, const double& approxAngle) {
     const double pi = atan(1) * 4.0;

--- a/src/utils/Geometry.h
+++ b/src/utils/Geometry.h
@@ -27,6 +27,7 @@ public:
     
 
     static TriV asTriV(const Element&, const Coordinates&);
+    static LinV asLinV(const Element&, const Coordinates&);
     
     static bool approxEqualLines(const LinV& a, const LinV& b);
     static bool approximatelyAligned(const TriV& a, const TriV& b, const double& angle);

--- a/src/utils/MeshTools.cpp
+++ b/src/utils/MeshTools.cpp
@@ -65,7 +65,7 @@ Grid getEnlargedGridIncludingAllElements(const Mesh& m)
 std::pair<VecD, VecD> getBoundingBox(const Mesh& m)
 {
     VecD minBB(std::numeric_limits<double>::max());
-    VecD maxBB(std::numeric_limits<double>::min());
+    VecD maxBB(std::numeric_limits<double>::lowest());
 
     GridTools gT{ m.grid };
     Coordinates newPos{ m.coordinates };

--- a/src/utils/Types.h
+++ b/src/utils/Types.h
@@ -40,6 +40,8 @@ using TriV = std::array<Coordinate, 3>;
 using QuaV = std::array<Coordinate, 4>;
 using TetV = std::array<Coordinate, 4>;
 using HexV = std::array<Coordinate, 8>;
+template<std::size_t N>
+using ElemV = std::array<Coordinate, N>;
 
 using LinVs = std::vector<LinV>;
 using TriVs = std::vector<TriV>;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(tessellator_tests
 	"tessellator/SmootherTest.cpp"
 	"tessellator/SmootherToolsTest.cpp"
 	"tessellator/SnapperTest.cpp"
+	"tessellator/StructurerTest.cpp"
 	"types/MeshTest.cpp"
 	"utils/CleanerTest.cpp"
 	"utils/CoordGraphTest.cpp"

--- a/test/tessellator/DriverTest.cpp
+++ b/test/tessellator/DriverTest.cpp
@@ -43,7 +43,7 @@ public:
 
     static auto getBoundingBoxOfUsedCoordinates(const Mesh& msh) {
         Coordinate min(std::numeric_limits<double>::max());
-        Coordinate max(std::numeric_limits<double>::min());
+        Coordinate max(std::numeric_limits<double>::lowest());
         for (auto const& g : msh.groups) {
             for (auto const& e : g.elements) {
                 for (auto const& vId : e.vertices) {

--- a/test/tessellator/StructurerTest.cpp
+++ b/test/tessellator/StructurerTest.cpp
@@ -1,0 +1,677 @@
+﻿#include "gtest/gtest.h"
+#include <gmock/gmock.h>
+#include <gmock/gmock-matchers.h>
+
+#include "MeshFixtures.h"
+
+#include "Structurer.h"
+#include "utils/Tools.h"
+#include "utils/Geometry.h"
+#include "utils/MeshTools.h"
+
+using namespace meshlib;
+using namespace tessellator;
+using namespace utils;
+using namespace meshFixtures;
+
+class StructurerTest : public ::testing::Test {
+protected:
+};
+
+TEST_F(StructurerTest, calculateStructuredCoordinateInExactSteps)
+{
+    float lowerCoordinateValue = -5.0;
+    float upperCoordinateValue = 5.0;
+    int numberOfCells = 6;
+    float step = 2.0;
+    assert((upperCoordinateValue - lowerCoordinateValue) / (numberOfCells - 1) == step);
+
+    Mesh mesh;
+    mesh.grid = GridTools::buildCartesianGrid(lowerCoordinateValue, upperCoordinateValue, numberOfCells);
+    Structurer structurer{ mesh };
+    ASSERT_NO_THROW(structurer.grid());
+
+    for (CellDir i = 0; i < mesh.grid[X].size(); ++i) {
+        CoordinateDir xDirection = RelativeDir(i);
+
+        for (CellDir j = 0; j < mesh.grid[Y].size(); ++j) {
+            CoordinateDir yDirection = RelativeDir(j);
+
+            for (CellDir k = 0; k < mesh.grid[Z].size(); ++k) {
+                CoordinateDir zDirection = RelativeDir(k);
+
+                Relative coordinate({ xDirection, yDirection, zDirection });
+                Cell expectedCell({ i, j, k });
+
+                auto resultCell = structurer.calculateStructuredCell(coordinate);
+
+                for (std::size_t axis = 0; axis < 3; ++axis) {
+                    EXPECT_EQ(resultCell[axis], expectedCell[axis]);
+                }
+            }
+        }
+    }
+}
+
+TEST_F(StructurerTest, calculateStructuredCoordinateBetweenSteps)
+{
+    float lowerCoordinateValue = -5.0;
+    float upperCoordinateValue = 5.0;
+    int numberOfCells = 3;
+    float step = 5.0;
+    assert((upperCoordinateValue - lowerCoordinateValue) / (numberOfCells - 1) == step);
+    float relativeStep = 1.0;
+    float quarterStep = relativeStep / 4.0f;
+    float halfStep = relativeStep / 2.0f;
+    float threeQuarterStep = relativeStep * 3.0f / 4.0f;
+
+    Mesh mesh;
+    mesh.grid = GridTools::buildCartesianGrid(lowerCoordinateValue, upperCoordinateValue, numberOfCells);
+    Structurer structurer{ mesh };
+    ASSERT_NO_THROW(structurer.grid());
+
+    for (CellDir i = 0; i < mesh.grid[X].size() - 1; ++i) {
+        for (CellDir j = 0; j < mesh.grid[Y].size() - 1; ++j) {
+            for (CellDir k = 0; k < mesh.grid[Z].size() - 1; ++k) {
+                Cell expectedLowerCell({ i, j, k });
+                Cell expectedUpperCell({ i + 1, j + 1, k + 1 });
+
+                Coordinate coordinateBase;
+                for (std::size_t axis = 0; axis < 3; ++axis) {
+                    coordinateBase[axis] = RelativeDir(expectedLowerCell[axis]);
+                }
+
+                Coordinate newCoordinate;
+                for (std::size_t axis = 0; axis < 3; ++axis) {
+                    newCoordinate[axis] = coordinateBase[axis] + quarterStep;
+                }
+
+                auto resultCell = structurer.calculateStructuredCell(newCoordinate);
+
+                for (std::size_t axis = 0; axis < 3; ++axis) {
+                    EXPECT_EQ(resultCell[axis], expectedLowerCell[axis]);
+                }
+
+                for (std::size_t axis = 0; axis < 3; ++axis) {
+                    newCoordinate[axis] = coordinateBase[axis] + halfStep;
+                }
+
+                resultCell = structurer.calculateStructuredCell(newCoordinate);
+
+                for (std::size_t axis = 0; axis < 3; ++axis) {
+                    EXPECT_EQ(resultCell[axis], expectedUpperCell[axis]);
+                }
+
+                for (std::size_t axis = 0; axis < 3; ++axis) {
+                    newCoordinate[axis] = coordinateBase[axis] + threeQuarterStep;
+                }
+
+                resultCell = structurer.calculateStructuredCell(newCoordinate);
+
+                for (std::size_t axis = 0; axis < 3; ++axis) {
+                    EXPECT_EQ(resultCell[axis], expectedUpperCell[axis]);
+                }
+            }
+        }
+    }
+}
+
+TEST_F(StructurerTest, transformSingleSegmentsIntoSingleStructuredElements)
+{
+
+    // *---------*      2--------*
+    // |  2      |      ‖         |
+	// |  |      |      ‖         |
+    // |  |  _-1 |  ->  ‖         |
+	// |  0-‾    |      ‖         |
+    // *---------*      0========1
+
+    float lowerCoordinateValue = -5.0;
+    float upperCoordinateValue = 5.0;
+    int numberOfCells = 3;
+    float step = 5.0;
+    assert((upperCoordinateValue - lowerCoordinateValue) / (numberOfCells - 1) == step);
+
+    Mesh mesh;
+    mesh.grid = GridTools::buildCartesianGrid(lowerCoordinateValue, upperCoordinateValue, numberOfCells);
+    mesh.coordinates = {
+        Coordinate({ 0.3, 0.3, 0.0 }),
+        Coordinate({ 0.7, 0.4, 0.0 }),
+        Coordinate({ 0.3, 0.7, 0.0 }),
+        Coordinate({ 0.3, 0.0, 0.7 }),
+    };
+    mesh.groups = { Group(), Group(), Group() };
+    mesh.groups[0].elements = {
+        Element({0, 1}, Element::Type::Line)
+    };
+    mesh.groups[1].elements = {
+        Element({0, 2}, Element::Type::Line)
+    };
+    mesh.groups[2].elements = {
+        Element({0, 3}, Element::Type::Line)
+    };
+
+    Coordinates expectedCoordinates = {
+        Coordinate({ 0.0, 0.0, 0.0 }),
+        Coordinate({ 1.0, 0.0, 0.0 }),
+        Coordinate({ 0.0, 1.0, 0.0 }),
+        Coordinate({ 0.0, 0.0, 1.0 }),
+    };
+
+    Elements expectedElements = {
+        Element({0, 1}, Element::Type::Line),
+        Element({0, 2}, Element::Type::Line),
+        Element({0, 3}, Element::Type::Line)
+    };
+
+    Mesh& resultMesh = Structurer{ mesh }.getMesh();
+
+    ASSERT_EQ(resultMesh.coordinates.size(), expectedCoordinates.size());
+    ASSERT_EQ(resultMesh.groups.size(), expectedElements.size());
+    ASSERT_EQ(resultMesh.groups[0].elements.size(), 1);
+    ASSERT_EQ(resultMesh.groups[1].elements.size(), 1);
+    ASSERT_EQ(resultMesh.groups[2].elements.size(), 1);
+
+    for (std::size_t i = 0; i < expectedCoordinates.size(); ++i) {
+        for (std::size_t axis = 0; axis < 3; ++axis) {
+            EXPECT_EQ(resultMesh.coordinates[i][axis], expectedCoordinates[i][axis]);
+        }
+    }
+    
+
+    for (std::size_t g = 0; g < expectedElements.size(); ++g) {
+        auto& resultGroup = resultMesh.groups[g];
+        auto& expectedElement = expectedElements[g];
+
+        EXPECT_TRUE(resultGroup.elements[0].isLine());
+        for (std::size_t i = 0; i < expectedElement.vertices.size(); ++i) {
+            EXPECT_EQ(resultGroup.elements[0].vertices[i], expectedElement.vertices[i]);
+        }
+    }
+}
+
+TEST_F(StructurerTest, transformSingleSegmentsIntoTwoStructuredElements)
+{
+
+    // *-----------*  {0.5->1}======={1->2}    *-----------*       *----------{3->2}
+    // |      1    |      ‖            |       |        3   |      |             ‖
+    // |     /     |      ‖            |       |       /    |      |             ‖
+    // |    /      |  ->  ‖            |       |      /     |  ->  |             ‖
+    // |  0        |      ‖            |       |    2       |      |             ‖
+    // *-----------*      0-----------*        *-----------*    {2->0}======={2.5->3}
+
+    float lowerCoordinateValue = -5.0;
+    float upperCoordinateValue = 5.0;
+    int numberOfCells = 3;
+    float step = 5.0;
+    assert((upperCoordinateValue - lowerCoordinateValue) / (numberOfCells - 1) == step);
+
+    Mesh mesh;
+    mesh.grid = GridTools::buildCartesianGrid(lowerCoordinateValue, upperCoordinateValue, numberOfCells);
+    mesh.coordinates = {
+        Coordinate({ 0.1,  0.1,  0.0 }),    // 0 First and Third Segments, First Point, X-Y and X-Z Planes
+        Coordinate({ 0.52, 0.9,  0.0 }),    // 1 First Segment, Final Point, X-Y Plane
+        Coordinate({ 0.48, 0.1,  0.0 }),    // 2 Second and Fourth Segments, First Point, X-Y and X-Z Planes
+        Coordinate({ 0.9,  0.9,  0.0 }),    // 3 Second Segment, Final Point, X-Y Plane
+        Coordinate({ 0.52, 0.0,  0.9 }),    // 4 Third Segment, Final Point, X-Z Plane
+        Coordinate({ 0.9,  0.0,  0.9 }),    // 5 Fourth Segment, Final Point, X-Z Plane
+        Coordinate({ 0.0,  0.1,  0.1 }),    // 6 Fifth Segment, First Point, Y-Z Plane
+        Coordinate({ 0.0,  0.52, 0.9 }),    // 7 Fifth Segment, First Point, Y-Z Plane
+        Coordinate({ 0.0,  0.48, 0.1 }),    // 8 Sixth Segment, First Point, Y-Z Plane
+        Coordinate({ 0.0,  0.9,  0.9 }),    // 9 Sixth Segment, First Point,  Y-Z Plane
+    };
+    mesh.groups.resize(6);
+    mesh.groups[0].elements = {
+        Element({0, 1}, Element::Type::Line)
+    };
+    mesh.groups[1].elements = {
+        Element({2, 3}, Element::Type::Line)
+    };
+    mesh.groups[2].elements = {
+        Element({0, 4}, Element::Type::Line)
+    };
+    mesh.groups[3].elements = {
+        Element({2, 5}, Element::Type::Line)
+    };
+    mesh.groups[4].elements = {
+        Element({6, 7}, Element::Type::Line)
+    };
+    mesh.groups[5].elements = {
+        Element({8, 9}, Element::Type::Line)
+    };
+
+    Coordinates expectedCoordinates = {
+        Coordinate({ 0.0, 0.0, 0.0 }),    // 0 All Segments, First Point
+        Coordinate({ 0.0, 1.0, 0.0 }),    // 1 First and Sixth Segment, Middle Point, X-Y and Y-Z Planes
+        Coordinate({ 1.0, 1.0, 0.0 }),    // 2 First and Second Segment, Final Point, X-Y Plane
+        Coordinate({ 1.0, 0.0, 0.0 }),    // 3 Second and Fourth Segment, Middle Point, X-Y and X-Z Planes
+        Coordinate({ 0.0, 0.0, 1.0 }),    // 4 Third and Fifth Segment, Middle Point X-Z and Y-Z Planes
+        Coordinate({ 1.0, 0.0, 1.0 }),    // 5 Third and Fourth Segments, Final Pint, X-Z Plane
+        Coordinate({ 0.0, 1.0, 1.0 }),    // 6 Fifth and Sixth Segments, Final Point, Y-Z Plane
+    };
+
+    std::vector<Elements> expectedElements = {
+        {
+            Element({0, 1}, Element::Type::Line),
+            Element({1, 2}, Element::Type::Line),
+        },
+        {
+            Element({0, 3}, Element::Type::Line),
+            Element({3, 2}, Element::Type::Line),
+        },
+        {
+            Element({0, 4}, Element::Type::Line),
+            Element({4, 5}, Element::Type::Line),
+        },
+        {
+            Element({0, 3}, Element::Type::Line),
+            Element({3, 5}, Element::Type::Line),
+        },
+        {
+            Element({0, 4}, Element::Type::Line),
+            Element({4, 6}, Element::Type::Line),
+        },
+        {
+            Element({0, 1}, Element::Type::Line),
+            Element({1, 6}, Element::Type::Line),
+        },
+    };
+
+    Mesh& resultMesh = Structurer{ mesh }.getMesh();
+
+    ASSERT_EQ(resultMesh.coordinates.size(), expectedCoordinates.size());
+    ASSERT_EQ(resultMesh.groups.size(), expectedElements.size());
+    ASSERT_EQ(resultMesh.groups[0].elements.size(), 2);
+    ASSERT_EQ(resultMesh.groups[1].elements.size(), 2);
+    ASSERT_EQ(resultMesh.groups[2].elements.size(), 2);
+    ASSERT_EQ(resultMesh.groups[3].elements.size(), 2);
+    ASSERT_EQ(resultMesh.groups[4].elements.size(), 2);
+    ASSERT_EQ(resultMesh.groups[5].elements.size(), 2);
+
+    for (std::size_t i = 0; i < expectedCoordinates.size(); ++i) {
+        for (std::size_t axis = 0; axis < 3; ++axis) {
+            EXPECT_EQ(resultMesh.coordinates[i][axis], expectedCoordinates[i][axis]);
+        }
+    }
+
+
+    for (std::size_t g = 0; g < expectedElements.size(); ++g) {
+        auto& resultGroup = resultMesh.groups[g];
+        auto& expectedGroup = expectedElements[g];
+
+        EXPECT_TRUE(resultGroup.elements[0].isLine());
+        EXPECT_TRUE(resultGroup.elements[1].isLine());
+
+        for (std::size_t i = 0; i < expectedGroup.size(); ++i) {
+            auto& resultElement = resultGroup.elements[i];
+            auto& expectedElement = expectedGroup[i];
+
+            for (std::size_t j = 0; j < expectedElement.vertices.size(); ++j) {
+                EXPECT_EQ(resultElement.vertices[j], expectedElement.vertices[j]);
+            }
+        }
+    }
+}
+
+
+
+TEST_F(StructurerTest, transformSingleSegmentsWithinDiagonalIntoTwoStructuredElements)
+{
+
+    // y                y                       y               y
+    // *-------*        *-------{1->2}          *------*    {3.5->4}======{4->5}
+    // |      1|        |          ‖            |      4|        ‖            |
+    // |    ╱  |        |          ‖            |    ╱  |        ‖            |
+    // |  ╱    |   ->   |          ‖            |  ╱    |   ->   ‖            |
+    // |0      |        |          ‖            |3      |        ‖            |
+    // *-------* x      0======{0.5->1} x       *------* z    {3->0}---------* z
+
+    float lowerCoordinateValue = -5.0;
+    float upperCoordinateValue = 5.0;
+    int numberOfCells = 3;
+    float step = 5.0;
+    assert((upperCoordinateValue - lowerCoordinateValue) / (numberOfCells - 1) == step);
+
+    Mesh mesh;
+    mesh.grid = GridTools::buildCartesianGrid(lowerCoordinateValue, upperCoordinateValue, numberOfCells);
+    mesh.coordinates = {
+        Coordinate({ 0.1, 0.1, 0.0 }),    // 0 First Segment, First Point, X-Y Plane
+        Coordinate({ 0.9, 0.9, 0.0 }),    // 1 First Segment, Final Point, X-Y Plane
+        Coordinate({ 0.1, 0.0, 0.1 }),    // 2 Second Segment, First Point, X-Z Plane
+        Coordinate({ 0.9, 0.0, 0.9 }),    // 3 Second Segment, Final Point, X-Z Plane
+        Coordinate({ 0.0, 0.1, 0.1 }),    // 4 Third Segment, First Point, Y-Z Plane
+        Coordinate({ 0.0, 0.9, 0.9 }),    // 5 Third Segment, Final Point, X-Z Plane
+    };
+    mesh.groups.resize(3);
+    mesh.groups[0].elements = {
+        Element({0, 1}, Element::Type::Line)
+    };
+    mesh.groups[1].elements = {
+        Element({2, 3}, Element::Type::Line)
+    };
+    mesh.groups[2].elements = {
+        Element({4, 5}, Element::Type::Line)
+    };
+
+    Coordinates expectedCoordinates = {
+        Coordinate({ 0.0, 0.0, 0.0 }),    // 0 All Segments, First Point, X-Y and X-Z Planes
+        Coordinate({ 1.0, 0.0, 0.0 }),    // 1 First and Second Segments, Middle Point, X-Y and X-Z Planes
+        Coordinate({ 1.0, 1.0, 0.0 }),    // 2 First Segment, Final Point, X-Y Plane
+        Coordinate({ 1.0, 0.0, 1.0 }),    // 3 Second Segment, Final Point, X-Z Plane
+        Coordinate({ 0.0, 1.0, 0.0 }),    // 4 Third Segment, Middle Point, X-Z Plane
+        Coordinate({ 0.0, 1.0, 1.0 }),    // 5 Third Segment, Final Point, X-Z Plane
+    };
+
+    std::vector<Elements> expectedElements = {
+        {
+            Element({0, 1}, Element::Type::Line),
+            Element({1, 2}, Element::Type::Line),
+        },
+        {
+            Element({0, 1}, Element::Type::Line),
+            Element({1, 3}, Element::Type::Line),
+        },
+        {
+            Element({0, 4}, Element::Type::Line),
+            Element({4, 5}, Element::Type::Line),
+        }
+    };
+
+    Mesh& resultMesh = Structurer{ mesh }.getMesh();
+
+    ASSERT_EQ(resultMesh.coordinates.size(), expectedCoordinates.size());
+    ASSERT_EQ(resultMesh.groups.size(), expectedElements.size());
+    ASSERT_EQ(resultMesh.groups[0].elements.size(), 2);
+    ASSERT_EQ(resultMesh.groups[1].elements.size(), 2);
+    ASSERT_EQ(resultMesh.groups[2].elements.size(), 2);
+    for (std::size_t i = 0; i < expectedCoordinates.size(); ++i) {
+        for (std::size_t axis = 0; axis < 3; ++axis) {
+            EXPECT_EQ(resultMesh.coordinates[i][axis], expectedCoordinates[i][axis]);
+        }
+    }
+
+
+    for (std::size_t g = 0; g < expectedElements.size(); ++g) {
+        auto& resultGroup = resultMesh.groups[g];
+        auto& expectedGroup = expectedElements[g];
+
+        EXPECT_TRUE(resultGroup.elements[0].isLine());
+        EXPECT_TRUE(resultGroup.elements[1].isLine());
+
+        for (std::size_t i = 0; i < expectedGroup.size(); ++i) {
+            auto& resultElement = resultGroup.elements[i];
+            auto& expectedElement = expectedGroup[i];
+
+            for (std::size_t j = 0; j < expectedElement.vertices.size(); ++j) {
+                EXPECT_EQ(resultElement.vertices[j], expectedElement.vertices[j]);
+            }
+        }
+    }
+}
+
+
+TEST_F(StructurerTest, transformSingleSegmentsIntoThreeStructuredElements)
+{
+
+    //     *-------------*               *----------{1->3}  
+    //    /|            /|              /|            /‖    
+    //   / |           / |             / |           / ‖    
+    // z/  |        1 /  |           z/  |          /  ‖    
+    // *---┼-----==‾+*   |    ->     *---┼---------*   ‖    
+    // |   |y _-‾   ¦|   |           |   |y        |   ‖    
+    // |  _*==------┴┼---*           |{0.33->1}===={0.67->2}    
+    // |0‾/          |  /            |  ⫽          ⎸  /
+    // |¦/           | /             | ⫽           ⎸ /
+    // |/            |/              |⫽            ⎸/
+    // *-------------* x             0-------------* x      
+
+    float lowerCoordinateValue = -5.0;
+    float upperCoordinateValue = 5.0;
+    int numberOfCells = 3;
+    float step = 5.0;
+    assert((upperCoordinateValue - lowerCoordinateValue) / (numberOfCells - 1) == step);
+
+    Mesh mesh;
+    mesh.grid = GridTools::buildCartesianGrid(lowerCoordinateValue, upperCoordinateValue, numberOfCells);
+    mesh.coordinates = {
+        Coordinate({ 0.0,  0.02, 0.04 }),    // 0 First, Third and Fourth Segments, First Point
+        Coordinate({ 1.0,  0.98, 0.52 }),    // 1 First and Second Segments, Final Point
+        Coordinate({ 0.0,  0.02, 0.48 }),    // 2 Second Segment, First Point
+        Coordinate({ 0.0,  0.48, 0.02 }),    // 3 Third Segment, First Point
+        Coordinate({ 0.52, 0.96, 0.8  }),    // 4 Third Segment, Final Point
+        Coordinate({ 1.0,  0.52, 0.54 }),    // 5 Fourth Segment, Final Point
+    };
+    mesh.groups.resize(4);
+    mesh.groups[0].elements = {
+        Element({0, 1}, Element::Type::Line),
+    };
+    mesh.groups[1].elements = {
+        Element({2, 1}, Element::Type::Line)
+    };
+    mesh.groups[2].elements = {
+        Element({3, 4}, Element::Type::Line)
+    };
+    mesh.groups[3].elements = {
+        Element({0, 5}, Element::Type::Line)
+    };
+
+    Coordinates expectedCoordinates = {
+        Coordinate({ 0.0, 0.0, 0.0 }),    // 0 All Segments Segments, First Point
+        Coordinate({ 0.0, 1.0, 0.0 }),    // 1 First and Third Segments, Second Point
+        Coordinate({ 1.0, 1.0, 0.0 }),    // 2 First Segment, Third Point
+        Coordinate({ 1.0, 1.0, 1.0 }),    // 3 All Segments, Final Point
+        Coordinate({ 0.0, 0.0, 1.0 }),    // 4 Second Segment, Second Point
+        Coordinate({ 0.0, 1.0, 1.0 }),    // 5 Second and Third Segments, Third Point
+        Coordinate({ 1.0, 0.0, 0.0 }),    // 6 Fourth Segment, Second Point
+        Coordinate({ 1.0, 0.0, 1.0 }),    // 7 Fourth Segment, Third Point
+    };
+
+    std::vector<Elements> expectedElements = {
+        {
+            Element({0, 1}, Element::Type::Line),
+            Element({1, 2}, Element::Type::Line),
+            Element({2, 3}, Element::Type::Line),
+        },
+        {
+            Element({0, 4}, Element::Type::Line),
+            Element({4, 5}, Element::Type::Line),
+            Element({5, 3}, Element::Type::Line),
+        },
+        {
+            Element({0, 1}, Element::Type::Line),
+            Element({1, 5}, Element::Type::Line),
+            Element({5, 3}, Element::Type::Line),
+        },
+        {
+            Element({0, 6}, Element::Type::Line),
+            Element({6, 7}, Element::Type::Line),
+            Element({7, 3}, Element::Type::Line),
+        },
+    };
+
+    Mesh& resultMesh = Structurer{ mesh }.getMesh();
+
+    ASSERT_EQ(resultMesh.coordinates.size(), expectedCoordinates.size());
+    ASSERT_EQ(resultMesh.groups.size(), expectedElements.size());
+    ASSERT_EQ(resultMesh.groups[0].elements.size(), 3);
+    ASSERT_EQ(resultMesh.groups[1].elements.size(), 3);
+    ASSERT_EQ(resultMesh.groups[2].elements.size(), 3);
+    ASSERT_EQ(resultMesh.groups[3].elements.size(), 3);
+    for (std::size_t i = 0; i < expectedCoordinates.size(); ++i) {
+        for (std::size_t axis = 0; axis < 3; ++axis) {
+            EXPECT_EQ(resultMesh.coordinates[i][axis], expectedCoordinates[i][axis]);
+        }
+    }
+
+
+    for (std::size_t g = 0; g < expectedElements.size(); ++g) {
+        auto& resultGroup = resultMesh.groups[g];
+        auto& expectedGroup = expectedElements[g];
+
+        EXPECT_TRUE(resultGroup.elements[0].isLine());
+        EXPECT_TRUE(resultGroup.elements[1].isLine());
+        EXPECT_TRUE(resultGroup.elements[2].isLine());
+
+        for (std::size_t i = 0; i < expectedGroup.size(); ++i)
+        {
+            auto& resultElement = resultGroup.elements[i];
+            auto& expectedElement = expectedGroup[i];
+
+            for (std::size_t j = 0; j < expectedElement.vertices.size(); ++j) {
+                EXPECT_EQ(resultElement.vertices[j], expectedElement.vertices[j]);
+            }
+        }
+    }
+}
+
+
+TEST_F(StructurerTest, transformSingleSegmentsWithinDiagonalIntoThreeStructuredElements)
+{
+
+    //     *-------------*               *----------{1->3}  
+    //    /|           2/|              /|            /‖    
+    //   / |          ╱¦ |             / |           / ‖    
+    // z/  |        ╱ /¦ |           z/  |          /  ‖    
+    // *---┼------╱--* ¦ |    ->     *---┼---------*   ‖    
+    // |   |y   ╱    | ¦ |           |   |y        |   ‖    
+    // |   *--╱------┼-┼-*           |   *---------{0.67->2}    
+    // |  / ╱        |  /            |  /          |  ⫽     
+    // | /╱          | /             | /           | ⫽      
+    // |⌿0           ⎹/              ⎹/            ⎹⫽
+    // *-------------* x             0========={0.33->1} x      
+
+    float lowerCoordinateValue = -5.0;
+    float upperCoordinateValue = 5.0;
+    int numberOfCells = 3;
+    float step = 5.0;
+    assert((upperCoordinateValue - lowerCoordinateValue) / (numberOfCells - 1) == step);
+
+    Mesh mesh;
+    mesh.grid = GridTools::buildCartesianGrid(lowerCoordinateValue, upperCoordinateValue, numberOfCells);
+    mesh.coordinates = {
+        Coordinate({ 0.1, 0.1, 0.1 }),    // 0 First Segment, First Point and Eight Segment, Final Point
+        Coordinate({ 0.9, 0.9, 0.9 }),    // 1 First Segment, Final Point and Eight Segment, First Point
+        Coordinate({ 0.9, 0.1, 0.1 }),    // 2 Second Segment, First Point and Seventh Segment, Final point
+        Coordinate({ 0.1, 0.9, 0.9 }),    // 3 Second Segment, Final Point and Seventh Segment, First Point
+        Coordinate({ 0.1, 0.9, 0.1 }),    // 4 Third Segment, First Point and Sixth Segment, Final Point
+        Coordinate({ 0.9, 0.1, 0.9 }),    // 5 Third Segment, Final Point and Sixth Segment, First Point
+        Coordinate({ 0.1, 0.1, 0.9 }),    // 6 Fourth Segment, First Point and Fifth Segment, Final Point
+        Coordinate({ 0.9, 0.9, 0.1 }),    // 7 Fourth Segment, Final Point and Fifth Segment, First Point
+    };
+    mesh.groups.resize(8);
+    mesh.groups[0].elements = {
+        Element({0, 1}, Element::Type::Line),
+    };
+    mesh.groups[1].elements = {
+        Element({2, 3}, Element::Type::Line),
+    };
+    mesh.groups[2].elements = {
+        Element({4, 5}, Element::Type::Line),
+    };
+    mesh.groups[3].elements = {
+        Element({6, 7}, Element::Type::Line),
+    };
+    mesh.groups[4].elements = {
+        Element({7, 6}, Element::Type::Line),
+    };
+    mesh.groups[5].elements = {
+        Element({5, 4}, Element::Type::Line),
+    };
+    mesh.groups[6].elements = {
+        Element({3, 2}, Element::Type::Line),
+    };
+    mesh.groups[7].elements = {
+        Element({1, 0}, Element::Type::Line),
+    };
+
+    Coordinates expectedCoordinates = {
+        Coordinate({ 0.0, 0.0, 0.0 }),    // 0 First Segment, First Point; Second Segment, Second Point; Fifth Segment, Third Point and Eight Segment, Final Point
+        Coordinate({ 1.0, 0.0, 0.0 }),    // 1 First Segment, Second Point; Second Segment, First Point; Third Segment, Third Point and Seventh Segment, Final point
+        Coordinate({ 1.0, 1.0, 0.0 }),    // 2 First Segment, Third Point; Third Segment, Second Point; Fourth Segment, Final Point and Fifth Segment, First Point
+        Coordinate({ 1.0, 1.0, 1.0 }),    // 3 First Segment, Final Point; Fourth Segment, Third Point; Seventh Segment, Second Point and Eight Segment, First Point
+        Coordinate({ 0.0, 1.0, 0.0 }),    // 4 Second Segment, Third Point; Third Segment, First Point; Fifth Segment, Second Point and Sixth Segment, Final Point
+        Coordinate({ 0.0, 1.0, 1.0 }),    // 5 Second Segment, Final Point; Sixth Segment, Third Point; Seventh Segment, First Point and Eight Segment, Second Point
+        Coordinate({ 1.0, 0.0, 1.0 }),    // 6 Third Segment, Final Point; Fourth Segment, Second Point; Sixth Segment, First Point and Seventh Segment, Third Point
+        Coordinate({ 0.0, 0.0, 1.0 }),    // 7 Fourth Segment, First Point and Fifth Segment, Final Point; Sixth Segment, Second Point and Eight Segment, Third Point
+    };
+
+    std::vector<Elements> expectedElements = {
+        {
+            Element({0, 1}, Element::Type::Line),
+            Element({1, 2}, Element::Type::Line),
+            Element({2, 3}, Element::Type::Line),
+        },
+        {
+            Element({1, 0}, Element::Type::Line),
+            Element({0, 4}, Element::Type::Line),
+            Element({4, 5}, Element::Type::Line),
+        },
+        {
+            Element({4, 2}, Element::Type::Line),
+            Element({2, 1}, Element::Type::Line),
+            Element({1, 6}, Element::Type::Line),
+        },
+        {
+            Element({7, 6}, Element::Type::Line),
+            Element({6, 3}, Element::Type::Line),
+            Element({3, 2}, Element::Type::Line),
+        },
+        {
+            Element({2, 4}, Element::Type::Line),
+            Element({4, 0}, Element::Type::Line),
+            Element({0, 7}, Element::Type::Line),
+        },
+        {
+            Element({6, 7}, Element::Type::Line),
+            Element({7, 5}, Element::Type::Line),
+            Element({5, 4}, Element::Type::Line),
+        },
+        {
+            Element({5, 3}, Element::Type::Line),
+            Element({3, 6}, Element::Type::Line),
+            Element({6, 1}, Element::Type::Line),
+        },
+        {
+            Element({3, 5}, Element::Type::Line),
+            Element({5, 7}, Element::Type::Line),
+            Element({7, 0}, Element::Type::Line),
+        },
+    };
+
+    Mesh& resultMesh = Structurer{ mesh }.getMesh();
+
+    ASSERT_EQ(resultMesh.coordinates.size(), expectedCoordinates.size());
+    ASSERT_EQ(resultMesh.groups.size(), expectedElements.size());
+    ASSERT_EQ(resultMesh.groups[0].elements.size(), 3);
+    ASSERT_EQ(resultMesh.groups[1].elements.size(), 3);
+    ASSERT_EQ(resultMesh.groups[2].elements.size(), 3);
+    ASSERT_EQ(resultMesh.groups[3].elements.size(), 3);
+    ASSERT_EQ(resultMesh.groups[4].elements.size(), 3);
+    ASSERT_EQ(resultMesh.groups[5].elements.size(), 3);
+    ASSERT_EQ(resultMesh.groups[6].elements.size(), 3);
+    ASSERT_EQ(resultMesh.groups[7].elements.size(), 3);
+    for (std::size_t i = 0; i < expectedCoordinates.size(); ++i) {
+        for (std::size_t axis = 0; axis < 3; ++axis) {
+            EXPECT_EQ(resultMesh.coordinates[i][axis], expectedCoordinates[i][axis]);
+        }
+    }
+
+
+    for (std::size_t g = 0; g < expectedElements.size(); ++g) {
+        auto& resultGroup = resultMesh.groups[g];
+        auto& expectedGroup = expectedElements[g];
+
+        EXPECT_TRUE(resultGroup.elements[0].isLine());
+        EXPECT_TRUE(resultGroup.elements[1].isLine());
+        EXPECT_TRUE(resultGroup.elements[2].isLine());
+
+        for (std::size_t i = 0; i < expectedGroup.size(); ++i) {
+            auto& resultElement = resultGroup.elements[i];
+            auto& expectedElement = expectedGroup[i];
+
+            for (std::size_t j = 0; j < expectedElement.vertices.size(); ++j) {
+                EXPECT_EQ(resultElement.vertices[j], expectedElement.vertices[j]);
+            }
+        }
+    }
+}

--- a/test/tessellator/StructurerTest.cpp
+++ b/test/tessellator/StructurerTest.cpp
@@ -168,13 +168,13 @@ TEST_F(StructurerTest, transformSingleSegmentsIntoSingleStructuredElements)
 
     ASSERT_EQ(resultMesh.coordinates.size(), expectedCoordinates.size());
     ASSERT_EQ(resultMesh.groups.size(), expectedElements.size());
-    ASSERT_EQ(resultMesh.groups[0].elements.size(), 1);
-    ASSERT_EQ(resultMesh.groups[1].elements.size(), 1);
-    ASSERT_EQ(resultMesh.groups[2].elements.size(), 1);
+    for (std::size_t g = 0; g < resultMesh.groups.size(); ++g) {
+        ASSERT_EQ(resultMesh.groups[g].elements.size(), 1);
+    }                                 
 
-    for (std::size_t i = 0; i < expectedCoordinates.size(); ++i) {
+    for (std::size_t g = 0; g < expectedCoordinates.size(); ++g) {
         for (std::size_t axis = 0; axis < 3; ++axis) {
-            EXPECT_EQ(resultMesh.coordinates[i][axis], expectedCoordinates[i][axis]);
+            EXPECT_EQ(resultMesh.coordinates[g][axis], expectedCoordinates[g][axis]);
         }
     }
     
@@ -281,12 +281,9 @@ TEST_F(StructurerTest, transformSingleSegmentsIntoTwoStructuredElements)
 
     ASSERT_EQ(resultMesh.coordinates.size(), expectedCoordinates.size());
     ASSERT_EQ(resultMesh.groups.size(), expectedElements.size());
-    ASSERT_EQ(resultMesh.groups[0].elements.size(), 2);
-    ASSERT_EQ(resultMesh.groups[1].elements.size(), 2);
-    ASSERT_EQ(resultMesh.groups[2].elements.size(), 2);
-    ASSERT_EQ(resultMesh.groups[3].elements.size(), 2);
-    ASSERT_EQ(resultMesh.groups[4].elements.size(), 2);
-    ASSERT_EQ(resultMesh.groups[5].elements.size(), 2);
+    for (std::size_t g = 0; g < resultMesh.groups.size(); ++g) {
+        ASSERT_EQ(resultMesh.groups[g].elements.size(), 2);
+    }
 
     for (std::size_t i = 0; i < expectedCoordinates.size(); ++i) {
         for (std::size_t axis = 0; axis < 3; ++axis) {
@@ -381,9 +378,9 @@ TEST_F(StructurerTest, transformSingleSegmentsWithinDiagonalIntoTwoStructuredEle
 
     ASSERT_EQ(resultMesh.coordinates.size(), expectedCoordinates.size());
     ASSERT_EQ(resultMesh.groups.size(), expectedElements.size());
-    ASSERT_EQ(resultMesh.groups[0].elements.size(), 2);
-    ASSERT_EQ(resultMesh.groups[1].elements.size(), 2);
-    ASSERT_EQ(resultMesh.groups[2].elements.size(), 2);
+    for (std::size_t g = 0; g < resultMesh.groups.size(); ++g) {
+        ASSERT_EQ(resultMesh.groups[g].elements.size(), 2);
+    }
     for (std::size_t i = 0; i < expectedCoordinates.size(); ++i) {
         for (std::size_t axis = 0; axis < 3; ++axis) {
             EXPECT_EQ(resultMesh.coordinates[i][axis], expectedCoordinates[i][axis]);
@@ -461,9 +458,9 @@ TEST_F(StructurerTest, transformSingleSegmentsIntoThreeStructuredElements)
         Coordinate({ 1.0, 1.0, 0.0 }),    // 2 First Segment, Third Point
         Coordinate({ 1.0, 1.0, 1.0 }),    // 3 All Segments, Final Point
         Coordinate({ 0.0, 0.0, 1.0 }),    // 4 Second Segment, Second Point
-        Coordinate({ 0.0, 1.0, 1.0 }),    // 5 Second and Third Segments, Third Point
-        Coordinate({ 1.0, 0.0, 0.0 }),    // 6 Fourth Segment, Second Point
-        Coordinate({ 1.0, 0.0, 1.0 }),    // 7 Fourth Segment, Third Point
+        Coordinate({ 1.0, 0.0, 1.0 }),    // 5 Second and Fourth Segments, Third Point
+        Coordinate({ 0.0, 1.0, 1.0 }),    // 6 Third Segment, Third Point
+        Coordinate({ 1.0, 0.0, 0.0 }),    // 7 Fourth Segment, Second Point
     };
 
     std::vector<Elements> expectedElements = {
@@ -479,13 +476,13 @@ TEST_F(StructurerTest, transformSingleSegmentsIntoThreeStructuredElements)
         },
         {
             Element({0, 1}, Element::Type::Line),
-            Element({1, 5}, Element::Type::Line),
-            Element({5, 3}, Element::Type::Line),
+            Element({1, 6}, Element::Type::Line),
+            Element({6, 3}, Element::Type::Line),
         },
         {
-            Element({0, 6}, Element::Type::Line),
-            Element({6, 7}, Element::Type::Line),
-            Element({7, 3}, Element::Type::Line),
+            Element({0, 7}, Element::Type::Line),
+            Element({7, 5}, Element::Type::Line),
+            Element({5, 3}, Element::Type::Line),
         },
     };
 
@@ -493,10 +490,9 @@ TEST_F(StructurerTest, transformSingleSegmentsIntoThreeStructuredElements)
 
     ASSERT_EQ(resultMesh.coordinates.size(), expectedCoordinates.size());
     ASSERT_EQ(resultMesh.groups.size(), expectedElements.size());
-    ASSERT_EQ(resultMesh.groups[0].elements.size(), 3);
-    ASSERT_EQ(resultMesh.groups[1].elements.size(), 3);
-    ASSERT_EQ(resultMesh.groups[2].elements.size(), 3);
-    ASSERT_EQ(resultMesh.groups[3].elements.size(), 3);
+    for (std::size_t g = 0; g < resultMesh.groups.size(); ++g) {
+        ASSERT_EQ(resultMesh.groups[g].elements.size(), 3);
+    }
     for (std::size_t i = 0; i < expectedCoordinates.size(); ++i) {
         for (std::size_t axis = 0; axis < 3; ++axis) {
             EXPECT_EQ(resultMesh.coordinates[i][axis], expectedCoordinates[i][axis]);
@@ -642,17 +638,157 @@ TEST_F(StructurerTest, transformSingleSegmentsWithinDiagonalIntoThreeStructuredE
 
     ASSERT_EQ(resultMesh.coordinates.size(), expectedCoordinates.size());
     ASSERT_EQ(resultMesh.groups.size(), expectedElements.size());
-    ASSERT_EQ(resultMesh.groups[0].elements.size(), 3);
-    ASSERT_EQ(resultMesh.groups[1].elements.size(), 3);
-    ASSERT_EQ(resultMesh.groups[2].elements.size(), 3);
-    ASSERT_EQ(resultMesh.groups[3].elements.size(), 3);
-    ASSERT_EQ(resultMesh.groups[4].elements.size(), 3);
-    ASSERT_EQ(resultMesh.groups[5].elements.size(), 3);
-    ASSERT_EQ(resultMesh.groups[6].elements.size(), 3);
-    ASSERT_EQ(resultMesh.groups[7].elements.size(), 3);
+    for (std::size_t g = 0; g < resultMesh.groups.size(); ++g) {
+        ASSERT_EQ(resultMesh.groups[g].elements.size(), 3);
+    }
     for (std::size_t i = 0; i < expectedCoordinates.size(); ++i) {
         for (std::size_t axis = 0; axis < 3; ++axis) {
             EXPECT_EQ(resultMesh.coordinates[i][axis], expectedCoordinates[i][axis]);
+        }
+    }
+
+
+    for (std::size_t g = 0; g < expectedElements.size(); ++g) {
+        auto& resultGroup = resultMesh.groups[g];
+        auto& expectedGroup = expectedElements[g];
+
+        EXPECT_TRUE(resultGroup.elements[0].isLine());
+        EXPECT_TRUE(resultGroup.elements[1].isLine());
+        EXPECT_TRUE(resultGroup.elements[2].isLine());
+
+        for (std::size_t i = 0; i < expectedGroup.size(); ++i) {
+            auto& resultElement = resultGroup.elements[i];
+            auto& expectedElement = expectedGroup[i];
+
+            for (std::size_t j = 0; j < expectedElement.vertices.size(); ++j) {
+                EXPECT_EQ(resultElement.vertices[j], expectedElement.vertices[j]);
+            }
+        }
+    }
+}
+
+
+TEST_F(StructurerTest, transformSingleSegmentsParallelWithDiagonalIntoThreeStructuredElements)
+{
+
+    //     *----------2--*          {0.67->2}========{1->3}  
+    //    /|         ╱¦ /|              /‖             /|    
+    //   / |       ╱  ¦╱ |             / ‖            / |    
+    // z/  |     ╱    ╱  |           z/  ‖           /  |    
+    // *---┼---╱-----*¦  |    ->     *---‖----------*   |    
+    // |   |y╱       |¦  |           |   ‖ y        ⎸   |    
+    // |   ╱---------┼┼--*           {0.67->2}-----┼---*   
+    // | ╱/          |  /            |  ⫽          ⎸  /     
+    // |0/           | /             | ⫽           ⎸ /      
+    // |∤            ⎹/              ⎹⫽            ⎸/       
+    // *-------------* x             *-------------* x  
+
+    float lowerCoordinateValue = -5.0;
+    float upperCoordinateValue = 5.0;
+    int numberOfCells = 3;
+    float step = 5.0;
+    assert((upperCoordinateValue - lowerCoordinateValue) / (numberOfCells - 1) == step);
+
+    Mesh mesh;
+    mesh.grid = GridTools::buildCartesianGrid(lowerCoordinateValue, upperCoordinateValue, numberOfCells);
+    mesh.coordinates = {
+        Coordinate({ 0.10, 0.20, 0.20 }),   //  0 First Segment, First Point
+        Coordinate({ 0.70, 0.80, 0.80 }),   //  1 First Segment, Final Point
+        Coordinate({ 0.10, 0.15, 0.20 }),   //  2 Second Segment, First Point
+        Coordinate({ 0.70, 0.75, 0.80 }),   //  3 Second Segment, Final Point
+        Coordinate({ 0.10, 0.10, 0.20 }),   //  4 Third Segment, First Point
+        Coordinate({ 0.70, 0.70, 0.80 }),   //  5 Third Segment, Final Point
+        Coordinate({ 0.20, 0.10, 0.20 }),   //  6 Fourth Segment, First Point
+        Coordinate({ 0.80, 0.70, 0.80 }),   //  7 Fourth Segment, Final Point
+        Coordinate({ 0.20, 0.10, 0.10 }),   //  8 Fifth Segment, First Point
+        Coordinate({ 0.80, 0.70, 0.70 }),   //  9 Fifth Segment, Final Point
+        Coordinate({ 0.10, 0.20, 0.10 }),   // 10 Sixth Segment, First Point
+        Coordinate({ 0.70, 0.80, 0.70 }),   // 11 Sixth Segment, Final Point
+        Coordinate({ 0.70, 0.20, 0.20 }),   // 12 Seventh Segment, First Point
+        Coordinate({ 0.10, 0.80, 0.80 }),   // 13 Seventh Segment, Final Point
+    };
+    mesh.groups.resize(7);
+    mesh.groups[0].elements = {
+        Element({0, 1}, Element::Type::Line),
+    };
+    mesh.groups[1].elements = {
+        Element({2, 3}, Element::Type::Line),
+    };
+    mesh.groups[2].elements = {
+        Element({4, 5}, Element::Type::Line),
+    };
+    mesh.groups[3].elements = {
+        Element({6, 7}, Element::Type::Line),
+    };
+    mesh.groups[4].elements = {
+        Element({8, 9}, Element::Type::Line),
+    };
+    mesh.groups[5].elements = {
+        Element({10, 11}, Element::Type::Line),
+    };
+    mesh.groups[6].elements = {
+        Element({12, 13}, Element::Type::Line),
+    };
+
+    Coordinates expectedCoordinates = {
+        Coordinate({ 0.0, 0.0, 0.0 }),   // 0 First, Second, Third, Fourth, Fifth and Sixth Segments, First Point and Seventh Segment, Second Point
+        Coordinate({ 0.0, 1.0, 0.0 }),   // 1 First and Sixth Segments, Second Point and Seventh Segment, Third Point
+        Coordinate({ 0.0, 1.0, 1.0 }),   // 2 First and Second Segments, Third Point and Seventh Segment, Final Point
+        Coordinate({ 1.0, 1.0, 1.0 }),   // 3 First, Second, Third, Fourth, Fifth and Sixth Segments, Final Point
+        Coordinate({ 0.0, 0.0, 1.0 }),   // 4 Second and Third Segments, Second Point
+        Coordinate({ 1.0, 0.0, 1.0 }),   // 5 Third and Fourth Segments, Third Point
+        Coordinate({ 1.0, 0.0, 0.0 }),   // 6 Fourth and Fifht Segments, Second Point and Seventh Segment, First Point
+        Coordinate({ 1.0, 1.0, 0.0 }),   // 7 Fifth and Sixth Segments, Third Point
+    };
+
+    std::vector<Elements> expectedElements = {
+        {
+            Element({0, 1}, Element::Type::Line),
+            Element({1, 2}, Element::Type::Line),
+            Element({2, 3}, Element::Type::Line),
+        },
+        {
+            Element({0, 4}, Element::Type::Line),
+            Element({4, 2}, Element::Type::Line),
+            Element({2, 3}, Element::Type::Line),
+        },
+        {
+            Element({0, 4}, Element::Type::Line),
+            Element({4, 5}, Element::Type::Line),
+            Element({5, 3}, Element::Type::Line),
+        },
+        {
+            Element({0, 6}, Element::Type::Line),
+            Element({6, 5}, Element::Type::Line),
+            Element({5, 3}, Element::Type::Line),
+        },
+        {
+            Element({0, 6}, Element::Type::Line),
+            Element({6, 7}, Element::Type::Line),
+            Element({7, 3}, Element::Type::Line),
+        },
+        {
+            Element({0, 1}, Element::Type::Line),
+            Element({1, 7}, Element::Type::Line),
+            Element({7, 3}, Element::Type::Line),
+        },
+        {
+            Element({6, 0}, Element::Type::Line),
+            Element({0, 1}, Element::Type::Line),
+            Element({1, 2}, Element::Type::Line),
+        },
+    };
+
+    Mesh& resultMesh = Structurer{ mesh }.getMesh();
+
+    ASSERT_EQ(resultMesh.coordinates.size(), expectedCoordinates.size());
+    ASSERT_EQ(resultMesh.groups.size(), expectedElements.size());
+    for (std::size_t g = 0; g < resultMesh.groups.size(); ++g) {
+        ASSERT_EQ(resultMesh.groups[g].elements.size(), 3);
+    }
+    for (std::size_t i = 0; i < expectedCoordinates.size(); ++i) {
+        for (std::size_t axis = 0; axis < 3; ++axis) {
+            EXPECT_EQ(resultMesh.coordinates[i][axis], expectedCoordinates[i][axis], "coordinate " + std::string(i) + ", axis " + std::string(axis));
         }
     }
 

--- a/test/utils/GeometryTest.cpp
+++ b/test/utils/GeometryTest.cpp
@@ -342,13 +342,41 @@ TEST_F(GeometryTest, areAdjacent_for_tris)
 	}
 }
 
-TEST_F(GeometryTest, areAdjacent_for_lines) 
+TEST_F(GeometryTest, areAdjacent_for_lines)
 {
 	Element l1({ 0, 1 }, Element::Type::Line);
 	Element l2({ 1, 2 }, Element::Type::Line);
 	Element l3({ 2, 3 }, Element::Type::Line);
 
-	EXPECT_TRUE (Geometry::areAdjacentLines(l1, l2));
-	EXPECT_TRUE (Geometry::areAdjacentLines(l2, l3));
+	EXPECT_TRUE(Geometry::areAdjacentLines(l1, l2));
+	EXPECT_TRUE(Geometry::areAdjacentLines(l2, l3));
 	EXPECT_FALSE(Geometry::areAdjacentLines(l1, l3));
+}
+
+TEST_F(GeometryTest, convertElementToLinV)
+{
+	Mesh m;
+	m.grid = {
+		std::vector<double>({-5.0, 0.0, 5.0}),
+		std::vector<double>({-5.0, 0.0, 5.0}),
+		std::vector<double>({-5.0, 0.0, 5.0})
+	};
+	m.coordinates = {
+		Coordinate({ -2.5, -2.5, -2.5 }),   // 0
+		Coordinate({ +1.5, -3.5, +0.0 }),   // 1 First Segment, First Point
+		Coordinate({ +2.5, -4.5, +1.5 }),   // 1 First Segment, Final Point
+		Coordinate({ -5.0, +5.0, +0.0 }),   // 3 
+	};
+	m.groups.resize(1);
+	m.groups[0].elements = {
+		Element{ {1, 2}, Element::Type::Line }
+	};
+	LinV expectedLineV = LinV({ m.coordinates[1], m.coordinates[2] });
+	auto resultLineV = Geometry::asLinV(m.groups[0].elements[0], m.coordinates);
+	
+	for (std::size_t v = 0; v < 2; ++v) {
+		for (std::size_t axis = 0; axis < 3; ++axis) {
+			EXPECT_EQ(resultLineV[v][axis], expectedLineV[v][axis]);
+		}
+	}
 }


### PR DESCRIPTION
Changelog:

- Fixed bugs in min and max comparisons
- Created Structurer class
- Process Lines into Structured Lines
- Keep size 0 Lines as Node Elements
- Make slicer compatible with Line elements

To do:
- Make Collapser compatible with lines
- Delete or Fuse overlapping structured lines from the same group. 