### PR TITLE
Change build workflow to keep new changes (#61)

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -6,8 +6,6 @@ on:
       - main
 
 env:
-  WINDOWS_RELEASE_TAG: windows-x64-opensemba-tessellator-draft
-  LINUX_RELEASE_TAG: linux-opensemba-tessellator-draft
   WINDOWS_FILENAME: opensemba-tessellator-windows-x64.tar.gz
   LINUX_FILENAME: opensemba-tessellator-linux.tar.gz
 
@@ -16,6 +14,15 @@ concurrency:
   cancel-in-progress: true
   
 jobs:
+  timestamp:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      releaseDate: ${{ steps.get-date.outputs.innerReleaseDate }}
+    steps:
+      - id: get-date
+        run: echo "innerReleaseDate=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
   build-temporary-releases:
     strategy:
       matrix:
@@ -29,6 +36,8 @@ jobs:
 
     name: ${{ matrix.preset.os }} / ${{matrix.preset.name}} / ${{matrix.build-type}}
     runs-on: ${{ matrix.preset.os }}
+    needs: timestamp
+    if: ${{ needs.timestamp.outputs.releaseDate }}
 
     steps:
     - name: checkout repository
@@ -85,69 +94,42 @@ jobs:
 
     - name: Generating linux pre-release
       if: matrix.preset.name=='gnu'
-      uses: "marvinpinto/action-automatic-releases@latest"
+      uses: softprops/action-gh-release@v2
       with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "${{ env.LINUX_RELEASE_TAG }}"
+        draft: true
         prerelease: true
-        title: "${{matrix.preset.filename}} OpenSemba Tessellator draft release"
+        fail_on_unmatched_files: true
+        token: "${{ secrets.GITHUB_TOKEN }}"
+        tag_name: "${{ needs.timestamp.outputs.releaseDate }}-latest-opensemba-tessellator"
+        name: "OpenSemba Tessellator release"
         files: |
           ./build/bin/${{ env.LINUX_FILENAME }}
 
     - name: Generating windows pre-release
       if: matrix.preset.name=='msbuild'
-      uses: "marvinpinto/action-automatic-releases@latest"
+      uses: softprops/action-gh-release@v2
       with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "${{ env.WINDOWS_RELEASE_TAG }}"
+        draft: true
         prerelease: true
-        title: "${{matrix.preset.filename}} OpenSemba Tessellator draft release"
+        fail_on_unmatched_files: true
+        token: "${{ secrets.GITHUB_TOKEN }}"
+        tag_name: "${{ needs.timestamp.outputs.releaseDate }}-latest-opensemba-tessellator"
+        name: "OpenSemba Tessellator release"
         files: |
           ./build/bin/${{matrix.build-type}}/${{ env.WINDOWS_FILENAME }}
 
   make-release:
     name: combine releases
     runs-on: ubuntu-latest
-    needs: build-temporary-releases
+    needs: [timestamp, build-temporary-releases]
 
     steps:
-      - name: download windows tar file
-        uses: robinraju/release-downloader@v1
-        with:
-          repository: OpenSEMBA/tessellator
-          tag: ${{env.WINDOWS_RELEASE_TAG}}
-          fileName: ${{ env.WINDOWS_FILENAME }}
-
-      - name: download linux tar file
-        uses: robinraju/release-downloader@v1
-        with:
-          repository: OpenSEMBA/tessellator
-          tag: ${{env.LINUX_RELEASE_TAG}}
-          fileName: ${{ env.LINUX_FILENAME }}
-
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
-
       - name: Generating release
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: softprops/action-gh-release@v2
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "${{ steps.date.outputs.date }}-latest-opensemba-tessellator"
           prerelease: false
-          title: "${{ matrix.preset.filename }} OpenSemba Tessellator release"
-          files: |
-            ${{ env.WINDOWS_FILENAME }}
-            ${{ env.LINUX_FILENAME }}
-
-      - name: Clean old pre-release
-        uses: "sgpublic/delete-release-action@v1.2"
-        with:
-          pre-release-drop: true
-          pre-release-keep-count: -1
-          pre-release-drop-tag: true
-          draft-drop: true
-          draft-keep-count: -1
-          draft-drop-tag: true
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          tag_name: "${{ needs.timestamp.outputs.releaseDate }}-latest-opensemba-tessellator"
+          name: "OpenSemba Tessellator release"
+          generate_release_notes: true
+          make_latest: true

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -124,12 +124,22 @@ jobs:
     needs: [timestamp, build-temporary-releases]
 
     steps:
+      - name: checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Get Previous tag
+        id: latest
+        uses: WyriHaximus/github-action-get-previous-tag@v2
+
       - name: Generating release
         uses: softprops/action-gh-release@v2
         with:
           prerelease: false
+          make_latest: true
           token: "${{ secrets.GITHUB_TOKEN }}"
           tag_name: "${{ needs.timestamp.outputs.releaseDate }}-latest-opensemba-tessellator"
           name: "OpenSemba Tessellator release"
           generate_release_notes: true
-          make_latest: true
+          previous_tag: ${{ steps.latest.outputs.tag }}


### PR DESCRIPTION
Change build workflow so it creates complete information of every new commit since the previous release.

It might not work the first time, since it seems to ignore commits already used in a previous release message.